### PR TITLE
Add support for explicit decryption

### DIFF
--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -1531,6 +1531,36 @@ func TestVerifyCiphertextBadCiphertext(t *testing.T) {
 	}
 }
 
+func Decrypt(t *testing.T, fheUintType fheUintType) {
+	var value uint64
+	switch fheUintType {
+	case FheUint8:
+		value = 2
+	case FheUint16:
+		value = 4283
+	case FheUint32:
+		value = 1333337
+	}
+	c := &decrypt{}
+	depth := 1
+	state := newTestState()
+	state.interpreter.evm.depth = depth
+	addr := common.Address{}
+	readOnly := false
+	hash := verifyCiphertextInTestMemory(state.interpreter, value, depth, fheUintType).getHash()
+	out, err := c.Run(state, addr, addr, hash.Bytes(), readOnly)
+	if err != nil {
+		t.Fatalf(err.Error())
+	} else if len(out) != 32 {
+		t.Fatalf("decrypt expected output len of 32, got %v", len(out))
+	}
+	result := big.Int{}
+	result.SetBytes(out)
+	if result.Uint64() != value {
+		t.Fatalf("decrypt result not equal to value, result %v != value %v", result.Uint64(), value)
+	}
+}
+
 func TestFheAdd8(t *testing.T) {
 	FheAdd(t, FheUint8, false)
 }
@@ -1937,6 +1967,18 @@ func TestFheScalarMax16(t *testing.T) {
 
 func TestFheScalarMax32(t *testing.T) {
 	FheMax(t, FheUint32, true)
+}
+
+func TestDecrypt8(t *testing.T) {
+	Decrypt(t, FheUint8)
+}
+
+func TestDecrypt16(t *testing.T) {
+	Decrypt(t, FheUint16)
+}
+
+func TestDecrypt32(t *testing.T) {
+	Decrypt(t, FheUint32)
 }
 
 func TestUnknownCiphertextHandle(t *testing.T) {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -182,10 +182,13 @@ const (
 	FheUint16NegNotGas  uint64 = 108000
 	FheUint32NegNotGas  uint64 = 130000
 
-	// TODO: Cost will depend on the complexity of doing reencryption by the oracle.
+	// TODO: Costs will depend on the complexity of doing reencryption/decryption by the oracle.
 	FheUint8ReencryptGas  uint64 = 1000
 	FheUint16ReencryptGas uint64 = 1100
 	FheUint32ReencryptGas uint64 = 1200
+	FheUint8DecryptGas    uint64 = 600
+	FheUint16DecryptGas   uint64 = 700
+	FheUint32DecryptGas   uint64 = 800
 
 	// As of now, verification costs only cover ciphertext deserialization and assume there is no ZKPoK to verify.
 	FheUint8VerifyGas  uint64 = 200


### PR DESCRIPTION
Implement as a `decrypt` precompile that takes a ciphertext handle and returns a 32-byte array of a 256-bit big-endian unsigned integer.

Note that decrypt can be called in "oracle" mode only, i.e. on a validator node that has the FHE secret key. Furthermore, we don't store the decrypted result in the oracle/requires DB, making catching up of full nodes that don't have the FHE secret key impossible. Reason is that if decrypt is called in a txn, a full node will behave differently than a validator node. We will work on that in a future commit.