### PR TITLE
Add support for explicit decryption

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -182,10 +182,13 @@ const (
 	FheUint16NegNotGas  uint64 = 108000
 	FheUint32NegNotGas  uint64 = 130000
 
-	// TODO: Cost will depend on the complexity of doing reencryption by the oracle.
+	// TODO: Costs will depend on the complexity of doing reencryption/decryption by the oracle.
 	FheUint8ReencryptGas  uint64 = 1000
 	FheUint16ReencryptGas uint64 = 1100
 	FheUint32ReencryptGas uint64 = 1200
+	FheUint8DecryptGas    uint64 = 600
+	FheUint16DecryptGas   uint64 = 700
+	FheUint32DecryptGas   uint64 = 800
 
 	// As of now, verification costs only cover ciphertext deserialization and assume there is no ZKPoK to verify.
 	FheUint8VerifyGas  uint64 = 200
@@ -200,9 +203,10 @@ const (
 	// TODO: As of now, only support FheUint8. All optimistic require predicates are
 	// downcast to FheUint8 at the solidity level. Eventually move to ebool.
 	// If there is at least one optimistic require, we need to decrypt it as it was a normal FHE require.
-	// For every subsequent optimistic require, we need to multiply it with the current require value.
-	FheUint8OptimisticRequireGas    uint64 = FheUint8RequireGas
-	FheUint8OptimisticRequireMulGas uint64 = FheUint8MulGas
+	// For every subsequent optimistic require, we need to bitand it with the current require value - that
+	// works, because we assume requires have a value of 0 or 1.
+	FheUint8OptimisticRequireGas       uint64 = FheUint8RequireGas
+	FheUint8OptimisticRequireBitandGas uint64 = FheUint8BitwiseGas
 
 	// TODO: This will change once we have an FHE-based random generaration with different types.
 	FheRandGas uint64 = NetSstoreCleanGas + ColdSloadCostEIP2929


### PR DESCRIPTION
Implement as a `decrypt` precompile that takes a ciphertext handle and returns a 32-byte array of a 256-bit big-endian unsigned integer.

For now, we assume all validators have the full FHE secret key. Therefore, we start allowing encrypted require, optimistic require and decrypt in view functions (i.e. over the EthCall RPC) executed on validators. If executed on a full node, the view function would fail, though, as it would try fetch the decryption from the DB and it won't be there (unless the decryption was previously decrypted in a non-view function). That implementation will change once we start using threshold decryption.

Use bit AND for optimistic requires instead of 8 bit multiplication. Rationale is that since we ensure ebool values are either 0 or 1, using AND is faster than multiplication. Furthermore, don't do the AND when encountering the optimistic require. Instead, accumulate requires and do the AND operations at the end. That way, if a reversal happens for a different reason, we wouldn't have executed ANDs and would save some execution time.

If a decryption or an encrypted require is encountered when optimistic requires have been used before, we decrypt the AND-ed optimistic requires as part of the decryption or the decrypted require. Rationale is that optimistic requires only revert at the end of the transaction. However, we don't want to be decrypting (in require or decrypt) for no reason. That limits the amount of data leaked in case of an optimistic require reversal.

Add unit tests for encrypted require, optimistic require and decryption.