### PR TITLE
Reinstate plaintext fheRand with type support

### DIFF
--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -211,8 +211,10 @@ const (
 	FheUint8OptimisticRequireGas       uint64 = FheUint8RequireGas
 	FheUint8OptimisticRequireBitandGas uint64 = FheUint8BitwiseGas
 
-	// TODO: This will change once we have an FHE-based random generaration with different types.
-	FheRandGas uint64 = NetSstoreCleanGas + ColdSloadCostEIP2929
+	// TODO: These will change once we have an FHE-based random generaration.
+	FheUint8RandGas  uint64 = NetSstoreInitGas + 1000
+	FheUint16RandGas uint64 = FheUint8RandGas + 1000
+	FheUint32RandGas uint64 = FheUint16RandGas + 1000
 
 	// TODO: The values here are chosen somewhat arbitrarily (at least the 8 bit ones). Also, we don't
 	// take into account whether a ciphertext existed (either "current" or "original") for the given handle.


### PR DESCRIPTION
Use ChaCha20 for PRNG. Have a separate PRNG per contract by seeding it with a global plaintext seed as:
`contractSeed = Keccack256(globalSeed || contractAddress)`. Also, use a counter as a nonce that is persisted in the contract's protected storage, ensuring every contract has its own nonce.

Can only be called in transactions. Calling it in view functions (i.e. EthCall) will fail.

Make sure we don't garbage collect the nonce slot (slot 0) in protected storage by defining it as a reserved slot. That is a temporary solution that we will revise soon by only running garbage collection on actual ciphertext handles.