### PR TITLE
Add fheLib precompile with first fheAdd method

### DIFF
--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -469,6 +469,8 @@ func toPrecompileInput(isScalar bool, hashes ...common.Hash) []byte {
 	return ret
 }
 
+var scalarBytePadding = make([]byte, 31)
+
 func toLibPrecompileInput(method string, isScalar bool, hashes ...common.Hash) []byte {
 	ret := make([]byte, 0)
 	state := crypto.NewKeccakState()
@@ -485,10 +487,7 @@ func toLibPrecompileInput(method string, isScalar bool, hashes ...common.Hash) [
 		isScalarByte = 0
 	}
 	ret = append(ret, isScalarByte)
-	// padding
-	for i := 0; i < 31; i++ {
-		ret = append(ret, 0)
-	}
+	ret = append(ret, scalarBytePadding...)
 	return ret
 }
 


### PR DESCRIPTION
Fhe library precompiled, only with one method now.

I reuse code of current precompiles and just pass subslice of the previous solidity abi call convention to the existing precompile so everything works.

@tremblaythibaultl @dartdart26