### PR TITLE
Mitigate attacks on garbage collection

### DIFF
--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -2957,6 +2957,40 @@ func TestVerifyCiphertextInvalidType(t *testing.T) {
 	}
 }
 
+func TestTrivialEncryptInvalidType(t *testing.T) {
+	c := &trivialEncrypt{}
+	depth := 1
+	state := newTestState()
+	state.interpreter.evm.depth = depth
+	addr := common.Address{}
+	readOnly := false
+	invalidType := fheUintType(255)
+	input := make([]byte, 32)
+	input = append(input, byte(invalidType))
+	_, err := c.Run(state, addr, addr, input, readOnly)
+	if err == nil {
+		t.Fatalf("trivialEncrypt must have failed on invalid ciphertext type")
+	}
+}
+
+func TestCastInvalidType(t *testing.T) {
+	c := &cast{}
+	depth := 1
+	state := newTestState()
+	state.interpreter.evm.depth = depth
+	addr := common.Address{}
+	readOnly := false
+	invalidType := fheUintType(255)
+	hash := verifyCiphertextInTestMemory(state.interpreter, 1, depth, FheUint8).getHash()
+	input := make([]byte, 0)
+	input = append(input, hash.Bytes()...)
+	input = append(input, byte(invalidType))
+	_, err := c.Run(state, addr, addr, input, readOnly)
+	if err == nil {
+		t.Fatalf("cast must have failed on invalid ciphertext type")
+	}
+}
+
 func TestVerifyCiphertextInvalidSize(t *testing.T) {
 	c := &verifyCiphertext{}
 	depth := 1


### PR DESCRIPTION
This PR consists of, essentially, 3 changes:
1. Instead of storing ciphertexts (and their metadata) starting at location `keccak256(ciphertext)`, store them at location `keccak256(keccak256(ciphertext))`. That makes it hard for malicious users to force garbage collection on arbitrary locations in protected storage (by deserializing arbitrary positions as metadata).
2. Flag locations that contain ciphertext handles in protected storage by setting a flag at location `keccak256(keccak256(loc))`. That ensures malicious users can't first persist a handle without it being honestly obtainded and then, after it has been honestly obtained and stored at another location, overwrite the first location and mess up the refcount of the honestly verified one. The location is hashed twice to avoid clashes with cihpertexts (and their metadata) in protected storage. Here, we assume that a well-formed ciphertext cannot be 32 bytes long and, hence, be a valid location. To have a clash, there needs to be a hash collision.
3. Remove explicit reseved protected storage slots. Since we now hash ciphertext handles (in change 1), it is hard for malicious users to force garbage collection of reserved slots.

Note that these changes are backwards-incompatible with existing data on-chain and existing chains need to be restarted from genesis.

See the section on `Privileged Storage` in the whitepaper for more information:
https://github.com/zama-ai/fhevm/blob/main/fhevm-whitepaper.pdf

Resolves #168.